### PR TITLE
feat: add activity calendar to profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.dist
+.DS_Store
+dist

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,4 @@
+body {
+  font-family: sans-serif;
+  padding: 1rem;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import Profile from './pages/Profile';
+
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/profile" element={<Profile />} />
+    </Routes>
+  );
+}

--- a/src/components/ActivityCalendar.css
+++ b/src/components/ActivityCalendar.css
@@ -1,0 +1,17 @@
+.activity-calendar {
+  display: flex;
+}
+.week {
+  display: flex;
+  flex-direction: column;
+}
+.day {
+  width: 12px;
+  height: 12px;
+  margin: 1px;
+  background-color: #ebedf0;
+}
+.day.level-1 { background-color: #c6e48b; }
+.day.level-2 { background-color: #7bc96f; }
+.day.level-3 { background-color: #239a3b; }
+.day.level-4 { background-color: #196127; }

--- a/src/components/ActivityCalendar.jsx
+++ b/src/components/ActivityCalendar.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { format, subDays, addDays } from 'date-fns';
+import './ActivityCalendar.css';
+
+function getLevel(count) {
+  if (count >= 4) return 4;
+  return count;
+}
+
+export default function ActivityCalendar({ data }) {
+  const today = new Date();
+  const start = subDays(today, 364);
+  const days = [];
+  for (let d = start; d <= today; d = addDays(d, 1)) {
+    const dateStr = format(d, 'yyyy-MM-dd');
+    days.push({ date: dateStr, count: data[dateStr] || 0 });
+  }
+  const weeks = [];
+  for (let i = 0; i < days.length; i += 7) {
+    weeks.push(days.slice(i, i + 7));
+  }
+  return (
+    <div className="activity-calendar">
+      {weeks.map((week, wi) => (
+        <div className="week" key={wi}>
+          {week.map((day) => (
+            <div
+              key={day.date}
+              className={`day level-${getLevel(day.count)}`}
+              title={`${day.date}: ${day.count} actions`}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/activityTracker.js
+++ b/src/lib/activityTracker.js
@@ -1,0 +1,14 @@
+import { format } from 'date-fns';
+
+const STORAGE_KEY = 'userActivity';
+
+export function trackActivity() {
+  const today = format(new Date(), 'yyyy-MM-dd');
+  const data = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}');
+  data[today] = (data[today] || 0) + 1;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+export function getActivity() {
+  return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}');
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './App.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
+);

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,0 +1,20 @@
+import React, { useState } from 'react';
+import ActivityCalendar from '../components/ActivityCalendar';
+import { trackActivity, getActivity } from '../lib/activityTracker';
+
+export default function Profile() {
+  const [activity, setActivity] = useState(getActivity());
+
+  const handleLog = () => {
+    trackActivity('action');
+    setActivity(getActivity());
+  };
+
+  return (
+    <div>
+      <h1>Профиль сотрудника</h1>
+      <button onClick={handleLog}>Записать действие</button>
+      <ActivityCalendar data={activity} />
+    </div>
+  );
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,21 +1,27 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite'
-import path from 'path'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(),tailwindcss()],
+  plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      '@': path.resolve(__dirname, './src'),
     },
   },
   server: {
     host: '0.0.0.0',
     port: 5173,
     strictPort: false,
-    allowedHosts: ["5173-ivz0xpqwbezkacjojozdh-1c9d6d1e.manusvm.computer", "5173-irkhdlg33kowi29ceh5oy-219ce97c.manusvm.computer", "5174-irkhdlg33kowi29ceh5oy-219ce97c.manusvm.computer"]
-  }
-})
-
+    allowedHosts: [
+      '5173-ivz0xpqwbezkacjojozdh-1c9d6d1e.manusvm.computer',
+      '5173-irkhdlg33kowi29ceh5oy-219ce97c.manusvm.computer',
+      '5174-irkhdlg33kowi29ceh5oy-219ce97c.manusvm.computer',
+    ],
+  },
+});


### PR DESCRIPTION
## Summary
- add localStorage-powered activity tracker
- display GitHub-style heatmap on employee profile
- configure Vite path handling for ESM

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a743eab9308332a699a671bfd30296